### PR TITLE
fix: 修改 url encode 导致文件名中有空格时图床上传失败

### DIFF
--- a/Mac/Helpers/ImagesProcessor.swift
+++ b/Mac/Helpers/ImagesProcessor.swift
@@ -232,12 +232,10 @@ public class ImagesProcessor {
             try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: false, attributes: nil)
         } catch {}
 
-        guard var fileName = ImagesProcessor.getFileName(from: url, to: destination, ext: ext) else { return nil }
+        guard let fileName = ImagesProcessor.getFileName(from: url, to: destination, ext: ext) else { return nil }
 
         let to = destination.appendingPathComponent(fileName)
         try? data.write(to: to, options: .atomic)
-
-        fileName = fileName.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? fileName
 
         return "\(prefix)\(fileName)"
     }


### PR DESCRIPTION
这里不需要 url encode，因为如果文件名是：CleanShot 2025-01-02 at 17.52.25.png
在这里encode会变成：CleanShot%202025-01-02%20at%2017.52.25.png
后面在saveClipboard函数中执行这两行代码后：
 let imagePath = "\(note.project.url.path)\(path)"
let tempPath = URL(fileURLWithPath: imagePath)
tempPath中文件名会变为: CleanShot%25202025-01-02%2520at%252017.52.25.png，其中%会被encode成%25，导致文件找不到