### PR TITLE
Ensure split view divider color updates with theme

### DIFF
--- a/Controllers/MainWindowController.swift
+++ b/Controllers/MainWindowController.swift
@@ -137,6 +137,16 @@ class MainWindowController: NSWindowController, NSWindowDelegate, NSWindowRestor
             contentView.wantsLayer = true
             contentView.layer?.backgroundColor = backgroundColor.cgColor
         }
+
+        DispatchQueue.main.async { [weak window] in
+            guard
+                let viewController = window?.contentViewController as? ViewController
+            else {
+                return
+            }
+
+            viewController.updateDividers()
+        }
     }
 
     // MARK: - NSWindowRestoration


### PR DESCRIPTION
## Summary
- refresh the split view divider color any time the window appearance is applied so the divider follows the active theme

## Testing
- `swift build` *(fails: unable to fetch dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68c9435fbbfc8332881010c873607f30