### PR TITLE
Handle empty search gracefully

### DIFF
--- a/Controllers/ViewController+Data.swift
+++ b/Controllers/ViewController+Data.swift
@@ -217,13 +217,15 @@ extension ViewController {
     }
 
     private func handleSearchResults(searchParams: SearchParameters) {
+        let hasSelectedNote = notesTableView.getSelectedNote() != nil
+
         if !notesTableView.noteList.isEmpty {
             if !searchParams.filter.isEmpty {
                 selectNullTableRow(timer: true)
-            } else if !UserDefaultsManagement.isSingleMode {
+            } else if !UserDefaultsManagement.isSingleMode, !hasSelectedNote {
                 editArea.clear()
             }
-        } else if !UserDefaultsManagement.isSingleMode {
+        } else if !UserDefaultsManagement.isSingleMode, !hasSelectedNote {
             editArea.clear()
         }
 

--- a/Views/SearchTextField.swift
+++ b/Views/SearchTextField.swift
@@ -152,9 +152,15 @@ class SearchTextField: NSSearchField, NSSearchFieldDelegate {
     }
 
     @objc private func search() {
+        let searchText = stringValue
+
+        guard !searchText.isEmpty else {
+            vcDelegate.cleanSearchAndRestoreSelection()
+            return
+        }
+
         UserDataService.instance.searchTrigger = true
 
-        let searchText = stringValue
         var sidebarItem: SidebarItem?
 
         lastQueryLength = searchText.count


### PR DESCRIPTION
- avoid executing table updates when the search field is empty and instead restore the previous selection
- keep the edit area contents when search results return and a note remains selected