### PR TITLE
Restore compact MARK formatting

### DIFF
--- a/Business/HtmlManager.swift
+++ b/Business/HtmlManager.swift
@@ -73,7 +73,6 @@ class HtmlManager {
     }
 
     // MARK: - Bundle and Resource Management
-
     static func getDownViewBundle() -> Bundle? {
         guard let path = Bundle.main.path(forResource: "DownView", ofType: ".bundle") else { return nil }
         return Bundle(url: URL(fileURLWithPath: path))
@@ -108,7 +107,6 @@ class HtmlManager {
     }
 
     // MARK: - Template Processing
-
     static func htmlFromTemplate(_ htmlString: String, css: String, currentName: String) throws -> String {
         guard let bundle = getDownViewBundle(),
             let baseURL = getBaseURL(bundle: bundle)
@@ -199,7 +197,6 @@ class HtmlManager {
     }
 
     // MARK: - JavaScript Utilities
-
     static let checkImagesScript = """
         (function() {
             var images = document.getElementsByTagName('img');
@@ -221,7 +218,6 @@ class HtmlManager {
         """
 
     // MARK: - HTML Tag Protection
-
     static func protectHTMLTags(in content: String) -> (protectedContent: String, placeholders: [String: String]) {
         var protectedContent = content
         var placeholders: [String: String] = [:]

--- a/Business/PrefsModel.swift
+++ b/Business/PrefsModel.swift
@@ -27,11 +27,10 @@ protocol SettingsConfigurable {
 }
 
 // MARK: - General Settings Model
+/// Concrete configuration for the General preferences pane backed by `UserDefaultsManagement`.
 struct GeneralSettings: SettingsConfigurable {
     let category: PreferencesCategory = .general
     let title: String = I18n.str("General")
-
-    // Settings properties based on UserDefaultsManagement
     var appearanceType: AppearanceType {
         get { UserDefaultsManagement.appearanceType }
         set { UserDefaultsManagement.appearanceType = newValue }
@@ -64,11 +63,10 @@ struct GeneralSettings: SettingsConfigurable {
 }
 
 // MARK: - Editor Settings Model
+/// Configuration wrapper exposing editor related defaults for the preferences UI.
 struct EditorSettings: SettingsConfigurable {
     let category: PreferencesCategory = .editor
     let title: String = I18n.str("Editor")
-
-    // Font settings
     var editorFontName: String {
         get { UserDefaultsManagement.fontName }
         set { UserDefaultsManagement.fontName = newValue }
@@ -103,16 +101,10 @@ struct EditorSettings: SettingsConfigurable {
         get { UserDefaultsManagement.codeFontName }
         set { UserDefaultsManagement.codeFontName = newValue }
     }
-
-    // Editor behavior settings
     var editorLineBreak: String {
         get { UserDefaultsManagement.editorLineBreak }
         set { UserDefaultsManagement.editorLineBreak = newValue }
     }
-
-    // Removed codeBackground setting (deprecated)
-
-    // Preview settings
     var previewLocation: String {
         get { UserDefaultsManagement.previewLocation }
         set { UserDefaultsManagement.previewLocation = newValue }
@@ -142,3 +134,4 @@ struct EditorSettings: SettingsConfigurable {
         }
     }
 }
+

--- a/Business/Types.swift
+++ b/Business/Types.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 // MARK: - Note Types
-
 public enum NoteType: String, CaseIterable {
     case markdown = "md"
 
@@ -20,7 +19,6 @@ public enum NoteContainer: Int, CaseIterable {
 }
 
 // MARK: - UI Types
-
 enum SidebarItemType: Int {
     case All = 0x01
     case Trash = 0x02
@@ -35,7 +33,6 @@ public enum AppearanceType: Int {
 }
 
 // MARK: - Sorting Types
-
 public enum SortDirection: String {
     case asc
     case desc
@@ -49,7 +46,6 @@ public enum SortBy: String {
 }
 
 // MARK: - Attribute Types
-
 enum NoteAttribute {
     static let highlight = NSAttributedString.Key(rawValue: "com.tw93.search.highlight")
 
@@ -65,7 +61,6 @@ extension NSAttributedString.Key {
 }
 
 // MARK: - Configuration Types
-
 struct KeychainConfiguration {
     static let serviceName = "MiaoYanApp"
     static let accessGroup: String? = nil

--- a/Controllers/AppDelegate+URLRoutes.swift
+++ b/Controllers/AppDelegate+URLRoutes.swift
@@ -230,3 +230,4 @@ extension AppDelegate {
         controller.createNote(name: title, content: body)
     }
 }
+

--- a/Controllers/AppDelegate.swift
+++ b/Controllers/AppDelegate.swift
@@ -322,3 +322,4 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         }
     }
 }
+

--- a/Controllers/BasePrefsViewController.swift
+++ b/Controllers/BasePrefsViewController.swift
@@ -26,3 +26,4 @@ class BasePrefsViewController: NSViewController {
     @objc func setupUI() {}
     @objc func setupValues() {}
 }
+

--- a/Controllers/EditorPrefsViewController.swift
+++ b/Controllers/EditorPrefsViewController.swift
@@ -373,3 +373,4 @@ final class EditorPrefsViewController: BasePrefsViewController {
         }
     }
 }
+

--- a/Controllers/GeneralPrefsViewController.swift
+++ b/Controllers/GeneralPrefsViewController.swift
@@ -373,3 +373,4 @@ final class GeneralPrefsViewController: BasePrefsViewController {
         }
     }
 }
+

--- a/Controllers/MainWindowController.swift
+++ b/Controllers/MainWindowController.swift
@@ -150,7 +150,6 @@ class MainWindowController: NSWindowController, NSWindowDelegate, NSWindowRestor
     }
 
     // MARK: - NSWindowRestoration
-
     static func restoreWindow(withIdentifier identifier: NSUserInterfaceItemIdentifier, state: NSCoder, completionHandler: @escaping (NSWindow?, Error?) -> Void) {
         if identifier.rawValue == "myMainWindow" {
             let storyboard = NSStoryboard(name: "Main", bundle: nil)

--- a/Controllers/TypographyPrefsViewController.swift
+++ b/Controllers/TypographyPrefsViewController.swift
@@ -447,3 +447,4 @@ final class TypographyPrefsViewController: BasePrefsViewController {
         }
     }
 }
+

--- a/Controllers/ViewController+Action.swift
+++ b/Controllers/ViewController+Action.swift
@@ -6,7 +6,6 @@ import TelemetryDeck
 extension ViewController {
 
     // MARK: - IBAction Methods
-
     @IBAction func activeWindow(_ sender: Any) {
         activeShortcut()
     }
@@ -457,7 +456,6 @@ extension ViewController {
     }
 
     // MARK: - Note Operations
-
     @objc func moveNote(_ sender: NSMenuItem) {
         let project = sender.representedObject as! Project
 
@@ -725,7 +723,6 @@ extension ViewController {
     }
 
     // MARK: - File Operations
-
     public func copy(project: Project, url: URL) -> URL {
         let fileName = url.lastPathComponent
 
@@ -756,7 +753,6 @@ extension ViewController {
     }
 
     // MARK: - Menu Management
-
     func loadMoveMenu() {
         guard let vc = ViewController.shared(), let note = vc.notesTableView.getSelectedNote() else { return }
 
@@ -832,7 +828,6 @@ extension ViewController {
     }
 
     // MARK: - Clipboard Operations
-
     public func saveTextAtClipboard() {
         if let note = notesTableView.getSelectedNote() {
             let pasteboard = NSPasteboard.general
@@ -852,7 +847,6 @@ extension ViewController {
     }
 
     // MARK: - Export Operations
-
     func exportFile(type: String) {
         UserDefaultsManagement.isOnExport = true
 
@@ -928,7 +922,6 @@ extension ViewController {
     }
 
     // MARK: - Utility Methods
-
     func activeShortcut() {
         guard let mainWindow = MainWindowController.shared() else {
             return
@@ -957,7 +950,6 @@ extension ViewController {
     }
 
     // MARK: - Keyboard Event Handling
-
     // swiftlint:disable:next cyclomatic_complexity
     public func keyDown(with event: NSEvent) -> Bool {
 
@@ -1220,7 +1212,6 @@ extension ViewController {
     }
 
     // MARK: - Info Panel Management
-
     func toggleInfo() {
         if popoverVisible {
             popover.performClose(nil)
@@ -1238,3 +1229,4 @@ extension ViewController {
         toast(message: NSLocalizedString("🙊 In single open mode, Exit with Command+Shift+W ~", comment: ""))
     }
 }
+

--- a/Controllers/ViewController+Data.swift
+++ b/Controllers/ViewController+Data.swift
@@ -20,7 +20,6 @@ private struct UpdateContext {
 extension ViewController {
 
     // MARK: - Search and Filtering
-
     func updateTable(search: Bool = false, searchText: String? = nil, sidebarItem: SidebarItem? = nil, projects: [Project]? = nil, completion: @escaping () -> Void = {}) {
         let searchParams = prepareSearchParameters(searchText: searchText, sidebarItem: sidebarItem, projects: projects)
         let timestamp = Date().toMillis()
@@ -305,7 +304,6 @@ extension ViewController {
     }
 
     // MARK: - Data Sorting and Arrangement
-
     func reSortByDirection() {
         guard let vc = ViewController.shared() else { return }
         ascendingCheckItem.state = UserDefaultsManagement.sortDirection ? .off : .on
@@ -390,7 +388,6 @@ extension ViewController {
     }
 
     // MARK: - Selection Management
-
     @objc func selectNullTableRow(timer: Bool = false) {
         if timer {
             selectRowTimer.invalidate()
@@ -418,7 +415,6 @@ extension ViewController {
     }
 
     // MARK: - Data State Management
-
     func refreshMiaoYanNum() {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
             let messageText = NSLocalizedString("%d MiaoYan", comment: "")
@@ -454,7 +450,6 @@ extension ViewController {
     }
 
     // MARK: - CloudKit Data Sync
-
     #if CLOUDKIT
         func registerKeyValueObserver() {
             let keyStore = NSUbiquitousKeyValueStore()
@@ -490,7 +485,6 @@ extension ViewController {
     #endif
 
     // MARK: - Utility Methods
-
     public func contains(tag name: String, in tags: [String]) -> Bool {
         var found = false
         for tag in tags {
@@ -503,7 +497,6 @@ extension ViewController {
     }
 
     // MARK: - Sidebar Accessors
-
     func getSidebarProject() -> Project? {
         if storageOutlineView.selectedRow < 0 {
             return nil
@@ -536,7 +529,6 @@ extension ViewController {
     }
 
     // MARK: - Search and Input Management
-
     func focusSearchInput(firstResponder: NSResponder? = nil) {
         DispatchQueue.main.async {
             let index = self.notesTableView.selectedRow > -1 ? self.notesTableView.selectedRow : 0
@@ -560,3 +552,4 @@ extension ViewController {
         }
     }
 }
+

--- a/Controllers/ViewController+Editor.swift
+++ b/Controllers/ViewController+Editor.swift
@@ -558,3 +558,4 @@ extension ViewController {
         }
     }
 }
+

--- a/Controllers/ViewController+Layout.swift
+++ b/Controllers/ViewController+Layout.swift
@@ -4,7 +4,6 @@ import Cocoa
 extension ViewController {
 
     // MARK: - Properties
-
     var sidebarWidth: CGFloat {
         guard let splitView = sidebarSplitView,
             !splitView.subviews.isEmpty
@@ -18,7 +17,6 @@ extension ViewController {
     }
 
     // MARK: - Layout Management Methods
-
     func updateDividers() {
         guard sidebarSplitView != nil && splitView != nil else { return }
         setDividerColor(for: sidebarSplitView, hidden: sidebarWidth == 0)
@@ -69,7 +67,6 @@ extension ViewController {
     }
 
     // MARK: - Sidebar Management
-
     func hideSidebar(_ sender: Any) {
         guard sidebarWidth > 0 else { return }
 
@@ -107,7 +104,6 @@ extension ViewController {
     }
 
     // MARK: - Note List Management
-
     func showNoteList(_ sender: Any) {
         if notelistWidth == 0 {
             if sidebarWidth == 0 {
@@ -140,7 +136,6 @@ extension ViewController {
     }
 
     // MARK: - Toggle Actions
-
     @IBAction func toggleNoteList(_ sender: Any) {
         guard splitView != nil else { return }
 
@@ -162,7 +157,6 @@ extension ViewController {
     }
 
     // MARK: - Gesture Handling
-
     override func wantsScrollEventsForSwipeTracking(on axis: NSEvent.GestureAxis) -> Bool {
         axis == .horizontal
     }
@@ -259,7 +253,6 @@ extension ViewController {
     }
 
     // MARK: - Split View Delegate
-
     func splitViewWillResizeSubviews(_ notification: Notification) {
         editArea.updateTextContainerInset()
     }
@@ -291,7 +284,6 @@ extension ViewController {
     }
 
     // MARK: - View Resize
-
     func viewDidResize() {
         checkSidebarConstraint()
         checkTitlebarTopConstraint()
@@ -307,7 +299,6 @@ extension ViewController {
     }
 
     // MARK: - Table and Sidebar Layout
-
     func reloadSideBar() {
         guard let outline = storageOutlineView else {
             return
@@ -323,3 +314,4 @@ extension ViewController {
         notesTableView.reloadData()
     }
 }
+

--- a/Controllers/ViewController.swift
+++ b/Controllers/ViewController.swift
@@ -499,3 +499,4 @@ class ViewController:
         }
     }
 }
+

--- a/Extensions/MPreviewView+Export.swift
+++ b/Extensions/MPreviewView+Export.swift
@@ -75,7 +75,6 @@ class ExportCache {
 extension MPreviewView {
 
     // MARK: - Export Methods
-
     public func exportPdf() {
         guard let vc = ViewController.shared() else { return }
 
@@ -194,7 +193,6 @@ extension MPreviewView {
     }
 
     // MARK: - Export Helper Methods
-
     private func generateHtmlDirectly(note: Note, viewController: ViewController) {
         // Get the title on main thread first
         let currentName = viewController.titleLabel.stringValue
@@ -296,7 +294,6 @@ extension MPreviewView {
     }
 
     // MARK: - Export Result Handlers
-
     private func handlePDFExportResult(_ result: Result<Data, Error>, viewController: Any) {
         guard let vc = viewController as? ViewController else { return }
         switch result {
@@ -334,7 +331,6 @@ extension MPreviewView {
     }
 
     // MARK: - File Save Methods
-
     private func saveToDownloads(content: String, extension: String, viewController: Any) {
         let data = content.data(using: .utf8) ?? Data()
         saveToDownloads(data: data, extension: `extension`, viewController: viewController)
@@ -424,7 +420,6 @@ extension MPreviewView {
     }
 
     // MARK: - Content Size Helpers
-
     private func getContentHeight(completion: @escaping (CGFloat?) -> Void) {
         // Robust height calculation using several DOM properties
         let js = "(function(){var b=document.body,e=document.documentElement;return Math.max(b.scrollHeight,b.offsetHeight,e.clientHeight,e.scrollHeight,e.offsetHeight);})()"
@@ -468,3 +463,4 @@ extension MPreviewView {
         return pdfDocument.dataRepresentation()
     }
 }
+

--- a/Extensions/NSImage+.swift
+++ b/Extensions/NSImage+.swift
@@ -138,7 +138,6 @@ extension NSImage {
     }
 
     // MARK: Cropping
-
     /// Resize the image, to nearly fit the supplied cropping size
     /// and return a cropped copy the image.
     ///

--- a/Extensions/NSMutableAttributedString+.swift
+++ b/Extensions/NSMutableAttributedString+.swift
@@ -3,7 +3,6 @@ import Foundation
 
 extension NSMutableAttributedString {
     // MARK: - Letter Spacing Support
-
     public func applyEditorLetterSpacing(_ spacing: CGFloat? = nil) {
         let letterSpacing = spacing ?? UserDefaultsManagement.editorLetterSpacing
         guard letterSpacing != 0 else { return }

--- a/Extensions/String+.swift
+++ b/Extensions/String+.swift
@@ -154,3 +154,4 @@ extension NSString {
         return self.lineRange(for: NSRange(location: lineStart - 1, length: 0))
     }
 }
+

--- a/Helpers/KeychainPasswordItem.swift
+++ b/Helpers/KeychainPasswordItem.swift
@@ -2,7 +2,6 @@ import Foundation
 
 struct KeychainPasswordItem {
     // MARK: Types
-
     enum KeychainError: Error {
         case noPassword
         case unexpectedPasswordData
@@ -11,7 +10,6 @@ struct KeychainPasswordItem {
     }
 
     // MARK: Properties
-
     let service: String
 
     private(set) var account: String
@@ -148,7 +146,6 @@ struct KeychainPasswordItem {
     }
 
     // MARK: Convenience
-
     private static func keychainQuery(withService service: String, account: String? = nil, accessGroup: String? = nil) -> [String: AnyObject] {
         var query = [String: AnyObject]()
         query[kSecClass as String] = kSecClassGenericPassword

--- a/Helpers/NotesTextProcessor.swift
+++ b/Helpers/NotesTextProcessor.swift
@@ -19,7 +19,6 @@ public class NotesTextProcessor {
     public static var linkColor: NSColor { Theme.linkColor }
 
     // MARK: Syntax highlight customisation
-
     public static var syntaxColor = fontColor
 
     public static var font: NSFont {
@@ -628,7 +627,6 @@ public class NotesTextProcessor {
     public static let _tabWidth = 4
 
     // MARK: Headers
-
     /*
      Head
      ======
@@ -685,7 +683,6 @@ public class NotesTextProcessor {
     public static let headersAtxClosingRegex = MarklightRegex(pattern: headersAtxClosingPattern, options: [.allowCommentsAndWhitespace, .anchorsMatchLines])
 
     // MARK: Reference links
-
     /*
      TODO: we don't know how reference links are formed
      */
@@ -712,7 +709,6 @@ public class NotesTextProcessor {
     public static let referenceLinkRegex = MarklightRegex(pattern: referenceLinkPattern, options: [.allowCommentsAndWhitespace, .anchorsMatchLines])
 
     // MARK: Lists
-
     /*
      * First element
      * Second element
@@ -728,7 +724,6 @@ public class NotesTextProcessor {
     public static let listOpeningRegex = MarklightRegex(pattern: _listMarker, options: [.allowCommentsAndWhitespace])
 
     // MARK: Anchors
-
     /*
      [Title](http://example.com)
      */
@@ -814,7 +809,6 @@ public class NotesTextProcessor {
     public static let anchorInlineRegex = MarklightRegex(pattern: anchorInlinePattern, options: [.allowCommentsAndWhitespace, .dotMatchesLineSeparators])
 
     // MARK: Images
-
     /*
      ![Title](http://example.com/image.png)
      */
@@ -880,7 +874,6 @@ public class NotesTextProcessor {
     public static let allTodoInlineRegex = MarklightRegex(pattern: allTodoInlinePattern, options: [.allowCommentsAndWhitespace, .anchorsMatchLines])
 
     // MARK: Code
-
     /*
      ```
      Code
@@ -920,7 +913,6 @@ public class NotesTextProcessor {
     public static let codeSpanClosingRegex = MarklightRegex(pattern: codeSpanClosingPattern, options: [.allowCommentsAndWhitespace, .dotMatchesLineSeparators])
 
     // MARK: Block quotes
-
     /*
      > Quoted text
      */
@@ -945,12 +937,10 @@ public class NotesTextProcessor {
     public static let blockQuoteOpeningRegex = MarklightRegex(pattern: blockQuoteOpeningPattern, options: [.anchorsMatchLines])
 
     // MARK: App url
-
     fileprivate static let appUrlPattern = "(\\[\\[)(.+?[\\[\\]]*)\\]\\]"
     public static let appUrlRegex = MarklightRegex(pattern: appUrlPattern, options: [.anchorsMatchLines])
 
     // MARK: Bold
-
     fileprivate static let strictBoldPattern = "(^|[\\W_])(?:(?!\\1)|(?=^))(\\*|_)\\2(?=\\S)(.*?\\S)\\2\\2(?!\\2)(?=[\\W_]|$)"
     public static let strictBoldRegex = MarklightRegex(pattern: strictBoldPattern, options: [.anchorsMatchLines])
 
@@ -958,7 +948,6 @@ public class NotesTextProcessor {
     public static let boldRegex = MarklightRegex(pattern: boldPattern, options: [.allowCommentsAndWhitespace, .anchorsMatchLines])
 
     // MARK: Strike
-
     fileprivate static let strikePattern = "(\\~\\~) (?=\\S) (.+?[~]*) (?<=\\S) \\1"
     public static let strikeRegex = MarklightRegex(pattern: strikePattern, options: [.allowCommentsAndWhitespace, .anchorsMatchLines])
 
@@ -966,7 +955,6 @@ public class NotesTextProcessor {
     public static let codeLineRegex = MarklightRegex(pattern: codeLinePattern, options: [.allowCommentsAndWhitespace, .anchorsMatchLines])
 
     // MARK: HTML
-
     fileprivate static let htmlPattern = "<(\\S*)[^>]*>[^<]*<\\/(\\1)>"
     public static let htmlRegex = MarklightRegex(pattern: htmlPattern, options: [.allowCommentsAndWhitespace, .anchorsMatchLines])
 
@@ -981,7 +969,6 @@ public class NotesTextProcessor {
     public static let blankRegex = MarklightRegex(pattern: "\\s+", options: [.allowCommentsAndWhitespace])
 
     // MARK: Italic
-
     fileprivate static let strictItalicPattern = "(^|[\\s_])(?:(?!\\1)|(?=^))(\\*|_)(?=\\S)((?:(?!\\2).)*?\\S)\\2(?!\\2)(?=[\\s]|(?:[.,!?]\\s)|$)"
 
     public static let strictItalicRegex = MarklightRegex(pattern: strictItalicPattern, options: [.anchorsMatchLines])

--- a/Helpers/UserDefaultsManagement.swift
+++ b/Helpers/UserDefaultsManagement.swift
@@ -731,3 +731,4 @@ public enum UserDefaultsManagement {
         }
     }
 }
+

--- a/Views/EditTextView.swift
+++ b/Views/EditTextView.swift
@@ -333,7 +333,6 @@ class EditTextView: NSTextView, NSTextFinderClient {
         }
         restoreCursorPosition(needScrollToCursor: needScrollToCursor)
     }
-    // setTextColor() was unused and removed in favor of Theme.textColor where needed
     public func clear() {
         textStorage?.setAttributedString(NSAttributedString())
         markdownView?.isHidden = true
@@ -350,11 +349,12 @@ class EditTextView: NSTextView, NSTextFinderClient {
         }
         EditTextView.note = nil
     }
-    // MARK: - Removed Large Methods
+    // MARK: - Editor Utility Helpers
     // Complex logic moved to dedicated manager classes:
     // - ImagePreviewManager: Image preview functionality
     // - ClipboardManager: Clipboard operations
     // - EditorMenuManager: Menu operations
+    /// Returns the paragraph range containing the current selection, if available.
     func getParagraphRange() -> NSRange? {
         guard let vc = getViewController(),
             let editArea = vc.editArea,
@@ -817,3 +817,4 @@ class EditTextView: NSTextView, NSTextFinderClient {
         }
     }
 }
+

--- a/Views/MPreviewView.swift
+++ b/Views/MPreviewView.swift
@@ -421,3 +421,4 @@ class HandlerRevealBackgroundColor: NSObject, WKScriptMessageHandler {
         }
     }
 }
+

--- a/Views/NotesTableView.swift
+++ b/Views/NotesTableView.swift
@@ -461,7 +461,6 @@ class NotesTableView: NSTableView, NSTableViewDataSource,
     }
 
     // MARK: - Scroll Position Memory
-
     func saveScrollPosition() {
         guard let clipView = superview as? NSClipView else { return }
         let scrollPosition = clipView.bounds.origin.y

--- a/Views/PrefsSidebarView.swift
+++ b/Views/PrefsSidebarView.swift
@@ -176,3 +176,4 @@ final class PrefsSidebarCellView: NSTableCellView {
         titleLabel.stringValue = category.title
     }
 }
+

--- a/Views/Toast.swift
+++ b/Views/Toast.swift
@@ -3,7 +3,6 @@ import AppKit
 private var currentToast: NSView?
 
 // MARK: - Toast Manager
-
 // MARK: - Toast Configuration
 struct ToastConfiguration {
     let animationDuration: TimeInterval
@@ -88,7 +87,6 @@ class ToastManager {
 }
 
 // MARK: - Toast Factory
-
 class ToastFactory {
     static func makeToast(message: String, title: String? = nil, configuration: ToastConfiguration = .default) -> NSView {
         let container = NSView()
@@ -174,7 +172,6 @@ class ToastFactory {
 }
 
 // MARK: - NSViewController Extension
-
 extension NSViewController {
     public func toast(message: String, title: String) {
         let toast = ToastFactory.makeToast(message: message, title: title)
@@ -195,3 +192,4 @@ extension NSViewController {
         ToastManager.shared.dismissCurrentToast()
     }
 }
+


### PR DESCRIPTION
## Summary
- remove the blank lines after each `// MARK:` header across controllers, views, helpers, and business logic to match the preferred compact layout
- drop redundant inline comments and add concise documentation where context was missing, such as the preferences models and editor helpers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c945bf76608332902a41f197ee5c4f