### PR TITLE
fix: hide TOC panel during PDF export

### DIFF
--- a/Extensions/MPreviewView+Export.swift
+++ b/Extensions/MPreviewView+Export.swift
@@ -393,6 +393,16 @@ extension MPreviewView {
                             })();
                         """
                     self.evaluateJavaScript(titleScript) { _, _ in
+                        // Hide TOC before export so it doesn't appear in the PDF output
+                        self.evaluateJavaScript("""
+                            (function() {
+                                var tocNav = document.querySelector('.toc-nav');
+                                var tocTrigger = document.querySelector('.toc-hover-trigger');
+                                if (tocNav) tocNav.style.display = 'none';
+                                if (tocTrigger) tocTrigger.style.display = 'none';
+                            })();
+                            """, completionHandler: nil)
+
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                             let pdfConfig = WKPDFConfiguration()
 
@@ -411,6 +421,17 @@ extension MPreviewView {
                                     document.documentElement.classList.remove('print-pdf');
                                     document.body.classList.remove('print-pdf');
                                     """, completionHandler: nil)
+
+                                // Restore TOC after export completes
+                                self.evaluateJavaScript("""
+                                    (function() {
+                                        var tocNav = document.querySelector('.toc-nav');
+                                        var tocTrigger = document.querySelector('.toc-hover-trigger');
+                                        if (tocNav) tocNav.style.display = '';
+                                        if (tocTrigger) tocTrigger.style.display = '';
+                                    })();
+                                    """, completionHandler: nil)
+
                                 self.hasPreparedPPTExport = false
                                 vc.toastDismiss()
 


### PR DESCRIPTION
## Problem

When exporting a PDF, the floating TOC component (`.toc-nav` and `.toc-hover-trigger`) is rendered into the output:

- If the mouse is hovering over the preview area: the TOC panel appears on the right side of the PDF
- If the mouse has left: the collapsed trigger strip still appears at the PDF edge

## Root Cause

The export flow calls `createPDF()` directly on the current WebView render without hiding the TOC first. Since `.toc-nav` uses `position: fixed`, it is not affected by print CSS either.

## Fix

Inject JavaScript to hide the two TOC elements immediately before `createPDF()` is called, then restore them in the existing cleanup block after export completes.

```swift
// Before createPDF()
evaluateJavaScript("""
    (function() {
        var tocNav = document.querySelector('.toc-nav');
        var tocTrigger = document.querySelector('.toc-hover-trigger');
        if (tocNav) tocNav.style.display = 'none';
        if (tocTrigger) tocTrigger.style.display = 'none';
    })();
    """)

// After createPDF() cleanup
evaluateJavaScript("""
    (function() {
        var tocNav = document.querySelector('.toc-nav');
        var tocTrigger = document.querySelector('.toc-hover-trigger');
        if (tocNav) tocNav.style.display = '';
        if (tocTrigger) tocTrigger.style.display = '';
    })();
    """)
```

`display: none` removes the elements from the render tree entirely. `display = ''` clears the inline style without interfering with tocbot's class-based show/hide logic.

The change follows the same `evaluateJavaScript` pattern already used throughout `MPreviewView+Export.swift` and adds null guards so it is safe when TOC is not initialised (e.g. PPT mode).

## Testing

1. Open any `.md` file with 2+ headings
2. Hover over the preview area to expand the TOC panel
3. Export PDF — TOC does not appear in the output
4. Export PDF with TOC collapsed — trigger strip does not appear in the output
5. After export, TOC is still functional in the preview