### PR TITLE
fix: keep currently open note visible in list after Finder open

### DIFF
--- a/Business/Storage.swift
+++ b/Business/Storage.swift
@@ -505,8 +505,16 @@ class Storage {
             let url = document.url
 
             if let currentNoteURL = EditTextView.note?.url,
-                currentNoteURL == url
+                currentNoteURL.resolvingSymlinksInPath().path == url.resolvingSymlinksInPath().path
             {
+                // Re-use the existing Note object so the currently open file
+                // stays visible in the list after a single-mode reload.
+                if let existingNote = EditTextView.note {
+                    if existingNote.isPinned {
+                        pinned += 1
+                    }
+                    noteList.append(existingNote)
+                }
                 continue
             }
 


### PR DESCRIPTION
The recent Finder open fixes (#516, #517) left one remaining issue: when a second `.md` file is opened from Finder, the file already open in the editor disappears from the note list.

**Root cause:** `loadLabel` in `Storage.swift` explicitly skips the note currently open in the editor (`EditTextView.note?.url == url` → `continue`). On a single-mode reload triggered by opening a new file, this causes the open note to be excluded from the rebuilt `noteList`.

**Fix:** Instead of skipping entirely, re-use the existing `Note` object and append it to `noteList`. Also uses symlink-safe path comparison and accounts for the note's pinned state in the counter.