### PR TITLE
[codex] Normalize attachment filenames

### DIFF
--- a/Helpers/ImagesProcessor.swift
+++ b/Helpers/ImagesProcessor.swift
@@ -165,7 +165,7 @@ public class ImagesProcessor {
             var pathComponent = NSUUID().uuidString.lowercased() + "." + ext
 
             if let from = from {
-                pathComponent = from.lastPathComponent
+                pathComponent = normalizedAttachmentFileName(from.lastPathComponent, fallbackExtension: ext)
                 ext = from.pathExtension
             }
 
@@ -183,6 +183,33 @@ public class ImagesProcessor {
         }
 
         return name
+    }
+
+    private static func normalizedAttachmentFileName(_ fileName: String, fallbackExtension: String) -> String {
+        let url = URL(fileURLWithPath: fileName)
+        let ext = url.pathExtension.isEmpty ? fallbackExtension : url.pathExtension
+        let baseName = url.deletingPathExtension().lastPathComponent
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+
+        var normalized = ""
+        var lastWasSeparator = false
+
+        for scalar in baseName.unicodeScalars {
+            if allowed.contains(scalar) {
+                normalized.unicodeScalars.append(scalar)
+                lastWasSeparator = false
+            } else if !lastWasSeparator {
+                normalized.append("-")
+                lastWasSeparator = true
+            }
+        }
+
+        normalized = normalized.trimmingCharacters(in: CharacterSet(charactersIn: "-_"))
+        if normalized.isEmpty {
+            normalized = NSUUID().uuidString.lowercased()
+        }
+
+        return ext.isEmpty ? normalized : "\(normalized).\(ext)"
     }
 
     // Access note.project (@MainActor)


### PR DESCRIPTION
## Summary
- normalize local attachment filenames before saving them into /i or /files
- replace Markdown-unsafe filename characters with hyphens while preserving extensions
- keep existing collision handling for normalized names

## Root Cause
Dragged image filenames with spaces or punctuation were inserted into Markdown as raw link targets, for example ![](/i/ChatGPT Image May 5, 2026, 11_38_27 AM.png). These raw targets can fail Markdown parsing before the preview image resolver sees them.

## Validation
- swift build