### PR TITLE
Fix new note rendering in split mode

### DIFF
--- a/Controllers/ViewController+Action.swift
+++ b/Controllers/ViewController+Action.swift
@@ -153,7 +153,9 @@ extension ViewController {
     }
 
     @IBAction func fileName(_ sender: NSTextField) {
-        guard let note = notesTableView.getNoteFromSelectedRow() else {
+        let pendingNote = UserDataService.instance.pendingTitleChange?.note
+        let noteFromEditor = titleLabel.hasFocus() ? EditTextView.note : nil
+        guard let note = pendingNote ?? noteFromEditor ?? notesTableView.getNoteFromSelectedRow() else {
             return
         }
 
@@ -863,6 +865,19 @@ extension ViewController {
         editArea.string = text
         EditTextView.note = note
 
+        if sessionSplitMode {
+            let previewOptions = FillOptions(
+                highlight: false,
+                saveTyping: true,
+                force: true,
+                needScrollToCursor: false,
+                previewOnly: true,
+                animatePreview: false
+            )
+            editArea.fill(note: note, options: previewOptions)
+            editArea.markdownView?.setSplitChrome(true)
+        }
+
         // Move focus into the title field in the same frame, so the cursor is
         // already blinking by the time the table reload finishes.
         titleLabel.editModeOn()
@@ -932,8 +947,10 @@ extension ViewController {
             return
         }
 
-        notesTableView.selectRowIndexes([index], byExtendingSelection: false)
-        notesTableView.scrollRowToVisible(index)
+        notesTableView.selectRow(index, suppressSideEffects: true)
+        DispatchQueue.main.async { [weak self] in
+            self?.notesTableView.scrollRowToVisible(index)
+        }
     }
 
     private func removeForever() {


### PR DESCRIPTION
## What changed
- Render a newly created note into the split preview immediately when split mode is active.
- Keep the new note selection side-effect free during creation so the title field is not overwritten by the previous selection.
- Save title edits against the note currently bound to title editing before falling back to the selected table row.

## Why
When a note was created while split mode was already active, the existing preview view was removed and no new preview was installed. Later edits only attempted lightweight updates through markdownView, which was nil, so the right pane stayed blank until the user toggled modes.

The title issue came from the same creation window: table selection and title editing could briefly point at different notes, letting the previous selected note title leak into the new note workflow.

## Validation
- Built successfully with:
  xcodebuild -scheme MiaoYan -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build

A normal signed build was not available on this machine because the Mac Development certificate for team 5EH69Y5X38 is not installed.