### PR TITLE
🐛 Fix Markdown blocks after numeric inline math

### DIFF
--- a/Business/Markdown.swift
+++ b/Business/Markdown.swift
@@ -171,7 +171,8 @@ private func isCurrencyDollar(
     let isMathContinuation =
         next == 40 || next == 42 || next == 43 || next == 45 || next == 47 || next == 60
         || next == 61 || next == 62 || next == 92 || next == 94 || next == 95
-    return !isASCIIAlphaNumeric && !isMathContinuation
+    let isInlineMathClose = next == delimiter[0].value
+    return !isASCIIAlphaNumeric && !isMathContinuation && !isInlineMathClose
 }
 
 private func appendProtectedMathScalars(_ scalars: [Unicode.Scalar], to output: inout String) {

--- a/Business/Markdown.swift
+++ b/Business/Markdown.swift
@@ -169,7 +169,7 @@ private func isCurrencyDollar(
     let next = scalars[cursor].value
     let isASCIIAlphaNumeric = (48...57).contains(next) || (65...90).contains(next) || (97...122).contains(next)
     let isMathContinuation =
-        next == 42 || next == 43 || next == 45 || next == 47 || next == 60
+        next == 40 || next == 42 || next == 43 || next == 45 || next == 47 || next == 60
         || next == 61 || next == 62 || next == 92 || next == 94 || next == 95
     return !isASCIIAlphaNumeric && !isMathContinuation
 }

--- a/MiaoYanTests/HtmlManagerTests.swift
+++ b/MiaoYanTests/HtmlManagerTests.swift
@@ -154,6 +154,30 @@ final class HtmlManagerTests: XCTestCase {
             "`<script>$code_math$</script>`")
     }
 
+    func testNumericOnlyMathDoesNotConsumeFollowingMarkdownBlocks() throws {
+        let markdown = #"""
+            - Write $0$ if they agree.
+            - Write $1$ if they disagree.
+
+            The disagreement distance is $0.25$.
+
+            ## Counts
+
+            | Symbol | Example |
+            | ------ | ------- |
+            | $n$    | $100$ variables |
+            """#
+        let html = try XCTUnwrap(
+            renderMarkdownHTML(markdown: markdown, useGithubLineBreak: false)
+        )
+
+        XCTAssertEqual(html.components(separatedBy: "<li").count - 1, 2)
+        XCTAssertTrue(html.contains("<h2"))
+        XCTAssertTrue(html.contains("<table"))
+        XCTAssertTrue(html.contains("$0.25$"))
+        XCTAssertTrue(html.contains("$100$"))
+    }
+
     func testCoefficientParenthesisMathDoesNotConsumeFollowingTable() throws {
         let markdown = #"""
             $2(k-2)$

--- a/MiaoYanTests/HtmlManagerTests.swift
+++ b/MiaoYanTests/HtmlManagerTests.swift
@@ -154,6 +154,23 @@ final class HtmlManagerTests: XCTestCase {
             "`<script>$code_math$</script>`")
     }
 
+    func testCoefficientParenthesisMathDoesNotConsumeFollowingTable() throws {
+        let markdown = #"""
+            $2(k-2)$
+
+            | Symbol | Meaning |
+            | ------ | ------- |
+            | $n$    | Number of variables |
+            """#
+        let html = try XCTUnwrap(
+            renderMarkdownHTML(markdown: markdown, useGithubLineBreak: false)
+        )
+
+        XCTAssertTrue(html.contains("<table"))
+        XCTAssertTrue(html.contains("$2(k-2)$"))
+        XCTAssertTrue(html.contains("$n$"))
+    }
+
     func testPPTPreparationUsesTheSharedMathProtection() {
         let prepared = HtmlManager.prepareMarkdownForPPT(nestedUnderbraceFormula)
 


### PR DESCRIPTION
## What

- Treat `(` as a valid math continuation after an initial numeric coefficient.
- Recognize a closing `$` immediately after an integer or decimal numeric literal.
- Add regression coverage for `$2(k-2)$`, `$0$`, `$1$`, `$0.25$`, and `$100$` followed by Markdown block syntax.

## Why

The currency guard currently classifies the opening `$` in expressions such as `$2(k-2)$` and `$0.25$` as currency. Their closing `$` can then pair with a later math delimiter, causing the math-protection pass to encode intervening list markers, headings, and table pipes before cmark-gfm parses them.

A numeric token immediately followed by the same `$` delimiter is closed inline math, while unclosed prices such as `Price $100` continue to use the existing currency path.

## Test plan

- Assert that two numeric-math bullet items remain separate `<li>` elements.
- Assert that the following heading and table remain `<h2>` and `<table>` elements.
- Assert that integer, decimal, coefficient-parenthesis, and table-cell formulas are preserved.
- Existing currency tests continue to cover standalone prices on separate lines.
- GitHub Actions will run the macOS build, unit tests, iOS build, SwiftLint, and swift-format checks. No local checkout was retained for this web-only contribution.